### PR TITLE
fix(home/hyprland): get consistent cursors :D

### DIFF
--- a/modules/home/hyprland.nix
+++ b/modules/home/hyprland.nix
@@ -314,5 +314,21 @@
         wallpaper = config.hypr.wallpaper;
       };
     };
+
+    home.pointerCursor = {
+      gtk.enable = true;
+      x11.enable = true;
+      package = pkgs.rose-pine-cursor;
+      name = "BreezeX-RosePine-Linux";
+      size = 24;
+    };
+
+    gtk = {
+      enable = true;
+      cursorTheme = {
+        package = pkgs.rose-pine-cursor;
+        name = "BreezeX-RosePine-Linux";
+      };
+    };
   };
 }


### PR DESCRIPTION
### What does this PR do?

Fighting over cursors, to get the same one used EVERYTIME. 

Turns out that I need to configure both home manager, gtk  and hyprland to achieve that. 