### PR TITLE
chore(host/texcel): fallback to private driver, use kernel 6.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732453510,
-        "narHash": "sha256-mAOaLu++YRwOxCJ135Bhgf78WYhIKWHL2aGWCAoXoBg=",
+        "lastModified": 1732482255,
+        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd58a1132e9b7f121f65313bc662ad6c8a05f878",
+        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1732521221,
+        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
         "type": "github"
       },
       "original": {

--- a/hosts/texcel/configuration.nix
+++ b/hosts/texcel/configuration.nix
@@ -14,22 +14,15 @@
     ../../modules/system/gaming.nix
   ];
 
-  nixpkgs.config.allowUnfree = true;
+  boot.kernelPackages = pkgs.linuxPackages_latest;
   services.xserver.videoDrivers = ["nvidia"];
   hardware.graphics.enable32Bit = true;
   hardware.nvidia = {
-    open = true;
+    open = false;
     modesetting.enable = true;
     powerManagement.enable = true;
     nvidiaSettings = true;
-    package = config.boot.kernelPackages.nvidiaPackages.mkDriver {
-      version = "565.57.01";
-      sha256_64bit = "sha256-buvpTlheOF6IBPWnQVLfQUiHv4GcwhvZW3Ks0PsYLHo=";
-      sha256_aarch64 = "";
-      openSha256 = "sha256-/tM3n9huz1MTE6KKtTCBglBMBGGL/GOHi5ZSUag4zXA=";
-      settingsSha256 = "sha256-H7uEe34LdmUFcMcS6bz7sbpYhg9zPCb/5AmZZFTx1QA=";
-      persistencedSha256 = "";
-    };
+    package = config.boot.kernelPackages.nvidiaPackages.beta;
   };
 
   core = {

--- a/modules/system/core.nix
+++ b/modules/system/core.nix
@@ -62,6 +62,8 @@
       };
     };
 
+    nixpkgs.config.allowUnfree = true;
+
     time.timeZone = config.core.timezone;
     i18n.defaultLocale = config.core.locale;
 


### PR DESCRIPTION
### What odes this PR do?

This PR aims to use the latest kernel available on texcel.... which of course broke the Nvidia driver :upside_down_face:.

Turned out that:


- Using `nividiaPackage.beta` already installs 545.xx.xx. So no need to make a custom package
- Not using the opensource package  fixed the situation.  though sad face . 